### PR TITLE
Ignore js options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.2.1-0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.2.0",
+  "version": "2.2.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.2.0",
+  "version": "2.2.1-0",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "main": "dist/squatch.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.2.1-0",
+  "version": "2.2.1",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "main": "dist/squatch.js",

--- a/src/widgets/Widgets.ts
+++ b/src/widgets/Widgets.ts
@@ -238,7 +238,7 @@ export default class Widgets {
   ) {
     _log("Rendering Widget...");
     if (!response) throw new Error("Unable to get a response");
-    if (!response.jsOptions) throw new Error("Missing jsOptions in response");
+    // if (!response.jsOptions) throw new Error("Missing jsOptions in response");
 
     let widget;
     let displayOnLoad = false;

--- a/src/widgets/Widgets.ts
+++ b/src/widgets/Widgets.ts
@@ -238,7 +238,6 @@ export default class Widgets {
   ) {
     _log("Rendering Widget...");
     if (!response) throw new Error("Unable to get a response");
-    // if (!response.jsOptions) throw new Error("Missing jsOptions in response");
 
     let widget;
     let displayOnLoad = false;


### PR DESCRIPTION
## Description of the change

Allow the response to not have `jsOptions` so that people using "Classic" can easily upgrade to squatch.js v2

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: (DEV-2782)
 - Process.st launch checklist: (https://app.process.st/checklists/Squatchjs-JS-OPTIONS-n7KIJTuE6RCajhyxhPVNVg/tasks/tugLiKdT0kmFz3ZH9E5O6w)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
