### PR TITLE
Fixed jsdocs for EventApi's track

### DIFF
--- a/src/api/EventsApi.ts
+++ b/src/api/EventsApi.ts
@@ -56,7 +56,7 @@ export default class EventsApi {
    * Track an event for a user
    *
    * @param params Parameters for request
-   * @param params.jwt the JSON Web Token (JWT) that is used to authenticate the user
+   * @param options.jwt the JSON Web Token (JWT) that is used to authenticate the user
    *
    * @return An ID to confirm the event has been accepted for asynchronous processing
    */


### PR DESCRIPTION
## Description of the change

> docs for EventApi's track function were incorrect, jwt needs to be on `options.jwt` rather than `params.jwt`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: (PUT IT HERE)
 - Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
