### PR TITLE
Fix squatch auto loading bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1] - 2023-06-07
+
+### Fixed
+
+- Race condition with auto-popup fixed when using the squatch-js package from NPM or on Safari
+
 ## [2.5.0] - 2023-05-16
 
 ### Removed
@@ -30,7 +36,7 @@ var initObj = {
 squatch
   .widget(initObj)
   .then(function (response) {
-    const widget = response.widget
+    const widget = response.widget;
   })
   .catch(function (error) {
     console.log(error);
@@ -44,6 +50,7 @@ squatch
 ## [2.4.3] - 2023-04-20
 
 ### Changed
+
 - Updated license copyright to be in line with SaaSquatch open-source policy.
 
 ## [2.4.2] - 2023-04-10
@@ -287,8 +294,9 @@ No release notes.
 
 No release notes.
 
-[unreleased]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.5.0...HEAD
-[2.5.0]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.4.1...@saasquatch%2Fsquatch-js@2.5.0
+[unreleased]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.5.1...HEAD
+[2.5.1]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.5.0...@saasquatch%2Fsquatch-js@2.5.1
+[2.5.0]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.4.3...@saasquatch%2Fsquatch-js@2.5.0
 [2.4.3]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.4.2...@saasquatch%2Fsquatch-js@2.4.3
 [2.4.2]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.4.1...@saasquatch%2Fsquatch-js@2.4.2
 [2.4.1]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fsquatch-js@2.4.0...@saasquatch%2Fsquatch-js@2.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/squatch-js",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",

--- a/src/async.ts
+++ b/src/async.ts
@@ -12,11 +12,18 @@ export default function asyncLoad() {
   const loaded = window.squatch || null;
   const cached = window._squatch || null;
 
+  function auto() {
+    setTimeout(() => {
+      if (typeof window.squatch._auto !== "function") return auto();
+      window.squatch._auto();
+    }, 0);
+  }
+
   if (loaded && cached) {
     const ready = cached.ready || [];
 
     ready.forEach((cb) => setTimeout(() => cb(), 0));
-    setTimeout(() => window.squatch._auto(), 0);
+    auto();
 
     // @ts-ignore -- intetionally deletes `_squatch` to cleanup initialization
     window._squatch = undefined;


### PR DESCRIPTION
## Description of the change

> Fixes a race condition when using the squatch-js npm package that prevented squatch auto from loading.
> Was also happening for both the loader script and npm on macs / Safari.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: https://impact.atlassian.net/browse/SQDEV-3429
- Process.st launch checklist: https://app.process.st/runs/Squatch-Auto-bug-fix-rW7bvp4MHFoSvwtDEiZNvA

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [x] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
