### PR TITLE
CA: Fix duped custom elements registration for multiple loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added custom web-components `squatch-embed` and `squatch-popup` for easier widget rendering.
-- Support for additional namespacing of squatchjs
+## [2.6.1] - 2023-09-01
+
+- Fix customElementRegistry error that occurs when multiple instances of squatchjs are loaded on the same page.
 
 ## [2.6.0] - 2023-08-23
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/squatch-js",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.0",
+  "version": "2.6.1-0",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.1-0",
+  "version": "2.6.1",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",

--- a/src/squatch.ts
+++ b/src/squatch.ts
@@ -218,4 +218,10 @@ if (typeof document !== "undefined" && !window.SaaSquatchDoNotAutoDrop) {
   pushCookie();
 }
 
+// Show message if squatchjs has already been loaded on the page
+if (window["squatch"]?.init)
+  _log(
+    "Squatchjs is being loaded more than once. This may lead to multiple load events being sent, and inaccurate analytics."
+  );
+
 if (typeof document !== "undefined") asyncLoad();

--- a/src/squatch.ts
+++ b/src/squatch.ts
@@ -221,7 +221,7 @@ if (typeof document !== "undefined" && !window.SaaSquatchDoNotAutoDrop) {
 // Show message if squatchjs has already been loaded on the page
 if (window["squatch"]?.init)
   _log(
-    "Squatchjs is being loaded more than once. This may lead to multiple load events being sent, and inaccurate analytics."
+    "Squatchjs is being loaded more than once. This may lead to multiple load events being sent, duplicated widgets, and inaccurate analytics."
   );
 
 if (typeof document !== "undefined") asyncLoad();

--- a/src/widgets/EmbedWidget.ts
+++ b/src/widgets/EmbedWidget.ts
@@ -80,7 +80,6 @@ export default class EmbedWidget extends Widget {
           const { height } = entry.contentRect;
           // @ts-ignore -- number will be cast to string by browsers
           frame.height = height;
-          console.log("RESIZE");
         }
       });
 

--- a/src/widgets/declarative/DeclarativeWidgets.ts
+++ b/src/widgets/declarative/DeclarativeWidgets.ts
@@ -113,6 +113,6 @@ class ImpactEmbed extends DeclarativeEmbedWidget {}
 class ImpactPopup extends DeclarativePopupWidget {}
 
 if (!window.customElements.get("squatch-embed")) window.customElements.define("squatch-embed", SquatchEmbed);
-if (!window.customElements.get("impact-embed")) window.customElements.define("impact-embed", SquatchEmbed);
-if (!window.customElements.get("squatch-popup")) window.customElements.define("squatch-popup", SquatchEmbed);
-if (!window.customElements.get("impact-popup")) window.customElements.define("impact-popup", SquatchEmbed);
+if (!window.customElements.get("impact-embed")) window.customElements.define("impact-embed", ImpactEmbed);
+if (!window.customElements.get("squatch-popup")) window.customElements.define("squatch-popup", SquatchPopup);
+if (!window.customElements.get("impact-popup")) window.customElements.define("impact-popup", ImpactPopup);

--- a/src/widgets/declarative/DeclarativeWidgets.ts
+++ b/src/widgets/declarative/DeclarativeWidgets.ts
@@ -112,7 +112,11 @@ class SquatchPopup extends DeclarativePopupWidget {}
 class ImpactEmbed extends DeclarativeEmbedWidget {}
 class ImpactPopup extends DeclarativePopupWidget {}
 
-if (!window.customElements.get("squatch-embed")) window.customElements.define("squatch-embed", SquatchEmbed);
-if (!window.customElements.get("impact-embed")) window.customElements.define("impact-embed", ImpactEmbed);
-if (!window.customElements.get("squatch-popup")) window.customElements.define("squatch-popup", SquatchPopup);
-if (!window.customElements.get("impact-popup")) window.customElements.define("impact-popup", ImpactPopup);
+if (!window.customElements.get("squatch-embed"))
+  window.customElements.define("squatch-embed", SquatchEmbed);
+if (!window.customElements.get("impact-embed"))
+  window.customElements.define("impact-embed", ImpactEmbed);
+if (!window.customElements.get("squatch-popup"))
+  window.customElements.define("squatch-popup", SquatchPopup);
+if (!window.customElements.get("impact-popup"))
+  window.customElements.define("impact-popup", ImpactPopup);

--- a/src/widgets/declarative/DeclarativeWidgets.ts
+++ b/src/widgets/declarative/DeclarativeWidgets.ts
@@ -112,7 +112,7 @@ class SquatchPopup extends DeclarativePopupWidget {}
 class ImpactEmbed extends DeclarativeEmbedWidget {}
 class ImpactPopup extends DeclarativePopupWidget {}
 
-window.customElements.define("squatch-embed", SquatchEmbed);
-window.customElements.define("impact-embed", ImpactEmbed);
-window.customElements.define("squatch-popup", SquatchPopup);
-window.customElements.define("impact-popup", ImpactPopup);
+if (!window.customElements.get("squatch-embed")) window.customElements.define("squatch-embed", SquatchEmbed);
+if (!window.customElements.get("impact-embed")) window.customElements.define("impact-embed", SquatchEmbed);
+if (!window.customElements.get("squatch-popup")) window.customElements.define("squatch-popup", SquatchEmbed);
+if (!window.customElements.get("impact-popup")) window.customElements.define("impact-popup", SquatchEmbed);

--- a/test/specs/DeclarativeWidgets.feature
+++ b/test/specs/DeclarativeWidgets.feature
@@ -413,6 +413,17 @@ Feature: Declarative widgets using custom Web Components
     And the widget loads correctly
     Then an analytics load event will be logged
 
+  @minutia
+  Scenario: Custom element registration does not occur if already registered
+    Given squatchjs is loaded onto a page twice
+    When the page loads
+    Then the first load registers the following custom elements
+      | squatch-embed |
+      | squatch-popup |
+      | impact-embed  |
+      | impact-popup  |
+    When the second instance of squatchjs is loaded
+    Then it does not register any custom elements
 
 
 


### PR DESCRIPTION
## Description of the change

> Squatchjs may error out if loaded more than once due to multiple custom element registrations for "squatch-embed"

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: https://impact.atlassian.net/browse/SQDEV-3460
- Process.st launch checklist: https://app.process.st/runs/Squatchjs-Custom-Element-Registry-fix-jmt3Aymvxkyxfvu1mC9FEQ

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
