### PR TITLE
Add user registration event listener and clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.2] - 2024-02-06
+
+### Added
+- `sq:user-registration` event listener for Instant Access widgets to fire a Load Analytics API event on successful user registration within the widget.
+
 ## [2.6.1] - 2023-09-01
+
+### Fixed
 
 - Fix customElementRegistry error that occurs when multiple instances of squatchjs are loaded on the same page.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/squatch-js",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.1",
+  "version": "2.6.2-0",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.2-0",
+  "version": "2.6.2",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",

--- a/src/widgets/EmbedWidget.ts
+++ b/src/widgets/EmbedWidget.ts
@@ -89,6 +89,9 @@ export default class EmbedWidget extends Widget {
       if (this._shouldFireLoadEvent()) {
         this._loadEvent(_sqh);
         _log("loaded");
+      } else {
+        console.log("attaching");
+        this._attachLoadEventListener(frameDoc, _sqh);
       }
     });
   }
@@ -113,6 +116,9 @@ export default class EmbedWidget extends Widget {
     if ((this.context as UpsertWidgetContext).user) {
       this._loadEvent(_sqh);
       _log("loaded");
+    } else {
+      if (!frame.contentDocument) return;
+      this._attachLoadEventListener(frame.contentDocument, _sqh);
     }
   }
 
@@ -120,11 +126,15 @@ export default class EmbedWidget extends Widget {
     const frame = this._findFrame();
     if (!frame) return _log("no target element to close");
 
+    if (frame.contentDocument)
+      this._detachLoadEventListener(frame.contentDocument);
+
     const element = this._findElement();
 
     element.style.visibility = "hidden";
     element.style.height = "0";
     element.style["overflow-y"] = "hidden";
+
     _log("Embed widget closed");
   }
 

--- a/src/widgets/EmbedWidget.ts
+++ b/src/widgets/EmbedWidget.ts
@@ -89,7 +89,7 @@ export default class EmbedWidget extends Widget {
       if (this._shouldFireLoadEvent()) {
         this._loadEvent(_sqh);
         _log("loaded");
-      } else {
+      } else if (frameDoc) {
         this._attachLoadEventListener(frameDoc, _sqh);
       }
     });

--- a/src/widgets/EmbedWidget.ts
+++ b/src/widgets/EmbedWidget.ts
@@ -90,7 +90,6 @@ export default class EmbedWidget extends Widget {
         this._loadEvent(_sqh);
         _log("loaded");
       } else {
-        console.log("attaching");
         this._attachLoadEventListener(frameDoc, _sqh);
       }
     });

--- a/src/widgets/PopupWidget.ts
+++ b/src/widgets/PopupWidget.ts
@@ -169,7 +169,6 @@ export default class PopupWidget extends Widget {
         this._loadEvent(_sqh);
         _log("Popup opened");
       } else {
-        console.log("ATTACHED");
         this._attachLoadEventListener(frameDoc, _sqh);
       }
     });

--- a/src/widgets/PopupWidget.ts
+++ b/src/widgets/PopupWidget.ts
@@ -168,11 +168,18 @@ export default class PopupWidget extends Widget {
       if ((this.context as UpsertWidgetContext).user) {
         this._loadEvent(_sqh);
         _log("Popup opened");
+      } else {
+        console.log("ATTACHED");
+        this._attachLoadEventListener(frameDoc, _sqh);
       }
     });
   }
 
   close() {
+    const frame = this._findFrame();
+    if (frame?.contentDocument)
+      this._detachLoadEventListener(frame.contentDocument);
+
     const element = this.container ? this._findElement() : document.body;
     const parent = element.shadowRoot || element;
     const dialog = parent.querySelector(`#${this.id}`) as HTMLDialogElement;

--- a/src/widgets/Widget.ts
+++ b/src/widgets/Widget.ts
@@ -138,7 +138,6 @@ export default abstract class Widget {
     frameDoc: Document,
     sqh: ProgramLoadEvent | GenericLoadEvent
   ) {
-    console.log(this.loadEventListener);
     if (this.loadEventListener === null) {
       this.loadEventListener = (
         e: CustomEvent<{ userId: string; accountId: string }>

--- a/test/specs/InstantAccessRendering.feature
+++ b/test/specs/InstantAccessRendering.feature
@@ -36,6 +36,18 @@ Feature: Instant Access Widget rendering
     When the widget is loaded by squatchJs
     Then there will be no Load Analytics API event
 
+  @minutia
+  Scenario: A Load Analytics API event is fired by an Instant Access widget once a user has been registered within the widget
+    Given a widget is rendered with the code
+      """
+      squatch.widget(initObj)
+      """
+    And there is no user object or jwt in the initObj
+    When the widget is loaded by squatchJs
+    Then an event listener is attached to the widget iframe's document body
+    When a "sq:user-registration" event is fired from the widget
+    Then a Load Analytics API event is fired
+
   @landmine
   Scenario: Rendering a Verified Access widget with `squatch.widget` causes component errors
     Given a widget is rendered with the code


### PR DESCRIPTION
## Description of the change

> Consumes the `sq:user-registration` event to fire a load analytics event in instant access widgets once a user exists. `@saasquatch/component-boilerplate` update: https://github.com/saasquatch/program-tools/pull/375

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
