### PR TITLE
[Bug fix] include shareMedium in analytics load event if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/squatch-js",
-  "version": "2.6.3",
+  "version": "2.6.4-1",
   "description": "The official Referral SaaSquatch Javascript Web/Browser SDK https://docs.referralsaasquatch.com/developer/squatchjs/",
   "license": "MIT",
   "author": "ReferralSaaSquatch.com, Inc.",

--- a/src/api/AnalyticsApi.ts
+++ b/src/api/AnalyticsApi.ts
@@ -29,6 +29,10 @@ export default class AnalyticsApi {
   pushAnalyticsLoadEvent(params: SQHDetails) {
     if (!params.externalUserId || !params.externalAccountId) return;
 
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const shareMediumFromUrl = urlParams?.get("rsShareMedium");
+
     const tenantAlias = encodeURIComponent(params.tenantAlias);
     const accountId = encodeURIComponent(params.externalAccountId);
     const userId = encodeURIComponent(params.externalUserId);
@@ -36,8 +40,11 @@ export default class AnalyticsApi {
     const programId = params.programId
       ? `&programId=${encodeURIComponent(params.programId)}`
       : ``;
+    const shareMedium = shareMediumFromUrl
+      ? `&shareMedium=${encodeURIComponent(shareMediumFromUrl)}`
+      : ``;
 
-    const path = `/a/${tenantAlias}/widgets/analytics/loaded?externalAccountId=${accountId}&externalUserId=${userId}&engagementMedium=${engagementMedium}${programId}`;
+    const path = `/a/${tenantAlias}/widgets/analytics/loaded?externalAccountId=${accountId}&externalUserId=${userId}&engagementMedium=${engagementMedium}${shareMedium}${programId}`;
     const url = this.domain + path;
 
     return doPost(url, JSON.stringify({}));


### PR DESCRIPTION
## Description of the change

> shareMedium was not being included in analytics load event, this adds it to the query if available as a queryParam

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
